### PR TITLE
Exit loop immediately after a credential has been found

### DIFF
--- a/src/main/java/com/waytta/SaltAPIBuilder.java
+++ b/src/main/java/com/waytta/SaltAPIBuilder.java
@@ -591,6 +591,7 @@ public class SaltAPIBuilder extends Builder {
 	    for (StandardUsernamePasswordCredentials credential : credentials) {
 		if (credential.getId().equals(credentialsId)) {
 		    usedCredential = credential;
+		    break;
 		}
 	    }
 


### PR DESCRIPTION
Trivial improvement to exit loop immediately once a credential has been found in the loop.