### PR TITLE
Better error description when credential is null

### DIFF
--- a/src/main/java/com/waytta/SaltAPIBuilder.java
+++ b/src/main/java/com/waytta/SaltAPIBuilder.java
@@ -595,7 +595,7 @@ public class SaltAPIBuilder extends Builder {
 	    }
 
 	    if (usedCredential == null) {
-		return FormValidation.error("CredentialId error: " + usedCredential);
+		return FormValidation.error("CredentialId error: no credential found with given ID.");
 	    }
 
             if (!servername.matches("\\{\\{\\w+\\}\\}")) {


### PR DESCRIPTION
Got a 

    CredentialId error: null

Response when testing connection and had to look at the source code to see what was wrong (though it's intuitive I think).

Now instead the code would print

    CredentialId error: no credential found with given ID.