### PR TITLE
Use jenkins logging instead of printing debug info to console

### DIFF
--- a/src/main/java/com/waytta/SaltAPIBuilder.java
+++ b/src/main/java/com/waytta/SaltAPIBuilder.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
+import org.apache.log4j.Level;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -38,6 +40,7 @@ import net.sf.json.JSONSerializer;
 import net.sf.json.util.JSONUtils;
 
 public class SaltAPIBuilder extends Builder {
+    private static final Logger LOGGER = Logger.getLogger("com.waytta.saltstack");
 
     private final String servername;
     private final String authtype;
@@ -215,7 +218,6 @@ public class SaltAPIBuilder extends Builder {
             myJobPollTime = jobPollTime;
         }
 
-        Boolean mySaltMessageDebug = getDescriptor().getSaltMessageDebug();
         String myOutputFormat = getDescriptor().getOutputFormat();
         String myClientInterface = clientInterface;
         String myservername = Utils.paramorize(build, listener, servername);
@@ -261,9 +263,8 @@ public class SaltAPIBuilder extends Builder {
         JSONArray saltArray = new JSONArray();
         saltArray.add(saltFunc);
 
-        if (mySaltMessageDebug) {
-            listener.getLogger().println("[DEBUG] Sending JSON: " + saltArray.toString());
-        }
+        LOGGER.log(Level.DEBUG, "Sending JSON: " + saltArray.toString());
+        
 
         if (myBlockBuild == null) {
             // Set a sane default if uninitialized
@@ -371,9 +372,8 @@ public class SaltAPIBuilder extends Builder {
             return false;
         }
 
-        if (mySaltMessageDebug) {
-            listener.getLogger().println("[DEBUG] Received response: " + returnArray);
-        }
+        LOGGER.log(Level.DEBUG, "Received response: " + returnArray);
+
 
         boolean validFunctionExecution = Utils.validateFunctionCall(returnArray);
 
@@ -546,7 +546,6 @@ public class SaltAPIBuilder extends Builder {
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
         private int pollTime = 10;
-        private boolean saltMessageDebug;
         private String outputFormat = "json";
 
         public DescriptorImpl() {
@@ -562,7 +561,6 @@ public class SaltAPIBuilder extends Builder {
                 // Fall back to default
                 pollTime = 10;
             }
-            saltMessageDebug = formData.getBoolean("saltMessageDebug");
             outputFormat = formData.getString("outputFormat");
             save();
             return super.configure(req, formData);
@@ -570,10 +568,6 @@ public class SaltAPIBuilder extends Builder {
 
         public int getPollTime() {
             return pollTime;
-        }
-
-        public boolean getSaltMessageDebug() {
-            return saltMessageDebug;
         }
 
         public String getOutputFormat() {

--- a/src/main/java/com/waytta/SaltAPIBuilder.java
+++ b/src/main/java/com/waytta/SaltAPIBuilder.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+import java.util.logging.Level;
 
-import org.apache.log4j.Level;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -263,7 +263,7 @@ public class SaltAPIBuilder extends Builder {
         JSONArray saltArray = new JSONArray();
         saltArray.add(saltFunc);
 
-        LOGGER.log(Level.DEBUG, "Sending JSON: " + saltArray.toString());
+        LOGGER.log(Level.FINE, "Sending JSON: " + saltArray.toString());
         
 
         if (myBlockBuild == null) {
@@ -372,7 +372,7 @@ public class SaltAPIBuilder extends Builder {
             return false;
         }
 
-        LOGGER.log(Level.DEBUG, "Received response: " + returnArray);
+        LOGGER.log(Level.FINE, "Received response: " + returnArray);
 
 
         boolean validFunctionExecution = Utils.validateFunctionCall(returnArray);

--- a/src/main/resources/com/waytta/SaltAPIBuilder/global.jelly
+++ b/src/main/resources/com/waytta/SaltAPIBuilder/global.jelly
@@ -7,10 +7,6 @@
       <f:textbox default="120" value="${instance.pollTime}" />
     </f:entry>
 
-    <f:entry title="JSON Debug" description="Toggles display of json data being submitted to saltAPI">
-      <f:checkbox name="saltMessageDebug" checked="${instance.saltMessageDebug}"/>
-    </f:entry>
-
     <f:entry title="Display format" description="Configure display of SaltAPI response">
       <select name="outputFormat">
         <f:option value="json" selected="${instance.outputFormat == 'json'}">json</f:option>


### PR DESCRIPTION
To see what the plugin sends/receives to/from the saltapi, now just create a new jenkins logger.

Name: salt logs
Logger: com.waytta.saltstack
Log level: ALL (currently only logs to FINE, but this could always change)