### PR TITLE
Support Jenkins Pipeline Plugin through metastep

### DIFF
--- a/src/main/java/com/waytta/SaltAPIBuilder.java
+++ b/src/main/java/com/waytta/SaltAPIBuilder.java
@@ -222,8 +222,11 @@ public class SaltAPIBuilder extends Builder implements SimpleBuildStep {
 
     @Override
     public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener) throws InterruptedException, IOException {
-        listener.getLogger().println("Printed from pipeline");
-        perform(run, launcher, listener);
+        listener.getLogger().println("SaltStack: Started from Pipeline");
+        boolean success = perform(run, launcher, listener);
+        if (!success) {
+            throw new InterruptedException();
+        }
     }
 
     //    @Override

--- a/src/main/java/com/waytta/Utils.java
+++ b/src/main/java/com/waytta/Utils.java
@@ -13,8 +13,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import hudson.EnvVars;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
@@ -108,7 +108,7 @@ public class Utils {
 
     // replaces $string with value of env($string). Used in conjunction with
     // parameterized builds
-    public static String paramorize(AbstractBuild build, BuildListener listener, String paramer) {
+    public static String paramorize(Run build, TaskListener listener, String paramer) {
         Pattern pattern = Pattern.compile("\\{\\{\\w+\\}\\}");
         Matcher matcher = pattern.matcher(paramer);
         while (matcher.find()) {


### PR DESCRIPTION
Hi,

I managed to get your nice plugin working with Jenkins Pipeline as a metastep.

e.x.
`step([$class: 'SaltAPIBuilder', arguments: '', authtype: 'pam', clientInterfaces: [blockbuild: false, jobPollTime: '10', clientInterface: 'local'], credentialsId: '', function: 'cmd.run', kwarguments: '', mods: '', pillarkey: '', pillarvalue: '', saveEnvVar: false, servername: '', target: '', targettype: 'glob'])
`

Now I know from reading 'Issues' that you are working on a refactoring but I wanted to contribute as much as I could.

The process was really simple 
* replaced AbstractBuild with Run
* replaced BuildListener with TaskListener
* if the result of perform method is false then throw InterruptedException to let the pipeline know of the failure

I wanted to go one step further and expose this functionality through the Pipeline Groovy DSL (not as a metastep) but I didn't know what name would be preferable by you.

Thanks for your time.