### PR TITLE
Add file and auto eauth instance.authtypes

### DIFF
--- a/src/main/resources/com/waytta/SaltAPIBuilder/config.jelly
+++ b/src/main/resources/com/waytta/SaltAPIBuilder/config.jelly
@@ -11,6 +11,8 @@
 
   <f:entry title="Auth Type" field="authtype">
     <select name="authtype">
+      <f:option value="auto" selected="${instance.authtype == 'auto'}">auto</f:option>
+      <f:option value="file" selected="${instance.authtype == 'file'}">file</f:option>
       <f:option value="pam" selected="${instance.authtype == 'pam'}">pam</f:option>
       <f:option value="ldap" selected="${instance.authtype == 'ldap'}">ldap</f:option>
     </select>

--- a/src/main/resources/com/waytta/SaltAPIStep/config.jelly
+++ b/src/main/resources/com/waytta/SaltAPIStep/config.jelly
@@ -11,6 +11,8 @@
 
   <f:entry title="Auth Type" field="authtype">
     <select name="authtype">
+      <f:option value="auto" selected="${instance.authtype == 'auto'}">auto</f:option>
+      <f:option value="file" selected="${instance.authtype == 'file'}">file</f:option>
       <f:option value="pam" selected="${instance.authtype == 'pam'}">pam</f:option>
       <f:option value="ldap" selected="${instance.authtype == 'ldap'}">ldap</f:option>
     </select>


### PR DESCRIPTION
`salt.auth.file` is new in version 2018.3.0, and is useful for some cases. As is `salt.auth.auto`. Feedback welcome, but hopefully this small addition helps someone else use this cool plugin.